### PR TITLE
Apply filters before pagination

### DIFF
--- a/src/components/AllClasses.jsx
+++ b/src/components/AllClasses.jsx
@@ -3,9 +3,31 @@ import Select from 'react-select';
 
 const AllClasses = ({ classesData, searchTerm, isHonors, selectedDays, handleAddClass, daysOfWeek, setIsHonors, setSelectedDays, setSearchTerm, currentPage, setCurrentPage, classesPerPage, setClassesPerPage }) => {
     const daysOptions = daysOfWeek.map(day => ({ label: day, value: day }));  
+    
+    // We'll instantiate currentClasses with all of the classes, then apply different filter operations to show the final list
+    let currentClasses = classesData;
+
+    // Filter based on search term
+    currentClasses = classesData.filter((candidateClass) => 
+        candidateClass.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        candidateClass.course.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        candidateClass.courseNumber.toString().includes(searchTerm)
+    )
+
+    // Filter the classes based on honors status (if applicable)
+    currentClasses = currentClasses.filter(candidateClass =>
+        (!isHonors || candidateClass.honors)
+    )
+
+    // Filter the classes based on day of week
+    currentClasses = currentClasses.filter(candidateClass =>
+        (selectedDays.length === 0 || selectedDays.every(day => candidateClass.days.split(',').includes(day)))
+    )
+
+    // Apply pagination
     const indexOfLastClass = currentPage * classesPerPage;
     const indexOfFirstClass = indexOfLastClass - classesPerPage;
-    const currentClasses = classesData.slice(indexOfFirstClass, indexOfLastClass);
+    currentClasses = currentClasses.slice(indexOfFirstClass, indexOfLastClass);
 
     const classesPerPageOptions = [
         { value: 5, label: '5' },
@@ -66,17 +88,7 @@ const AllClasses = ({ classesData, searchTerm, isHonors, selectedDays, handleAdd
                 </tr>
                 </thead>
                 <tbody>
-                {currentClasses
-                    .filter(currentClasses =>
-                        currentClasses.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                        currentClasses.course.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                        currentClasses.courseNumber.toString().includes(searchTerm)
-                    )
-                    .filter(currentClasses =>
-                        (!isHonors || currentClasses.honors) &&
-                        (selectedDays.length === 0 || selectedDays.every(day => currentClasses.days.split(',').includes(day)))
-                    )
-                    .map((data, index) => (
+                {currentClasses.map((data, index) => (
                     <tr key={index} onClick={() => handleAddClass(data)} style={{cursor: 'pointer'}}>
                         <td>{data.subjectAbbreviation}</td>
                         <td>{data.courseNumber}</td>


### PR DESCRIPTION
When the user applies filters, we should first apply the filters and then paginate the results. If pagination is applied first, we are effectively filtering over only the page that is shown, which is not ideal.